### PR TITLE
Add notification to parent frame on submission

### DIFF
--- a/SurveyClient/src/main/java/uk/ac/ncl/openlab/intake24/client/BrowserWindow.java
+++ b/SurveyClient/src/main/java/uk/ac/ncl/openlab/intake24/client/BrowserWindow.java
@@ -1,0 +1,21 @@
+/*
+This file is part of Intake24.
+
+© Crown copyright, 2012, 2013, 2014.
+
+This software is licensed under the Open Government Licence 3.0:
+
+http://www.nationalarchives.gov.uk/doc/open-government-licence/
+*/
+
+package uk.ac.ncl.openlab.intake24.client;
+
+public class BrowserWindow {
+	public static native void postMessage(String msg) /*-{
+		$wnd.parent.postMessage(msg);
+	}-*/;
+
+	public static native void alert(String msg) /*-{
+		$wnd.alert(msg);
+	}-*/;
+}

--- a/SurveyClient/src/main/java/uk/ac/ncl/openlab/intake24/client/BrowserWindow.java
+++ b/SurveyClient/src/main/java/uk/ac/ncl/openlab/intake24/client/BrowserWindow.java
@@ -12,7 +12,7 @@ package uk.ac.ncl.openlab.intake24.client;
 
 public class BrowserWindow {
 	public static native void postMessage(String msg) /*-{
-		$wnd.parent.postMessage(msg);
+		$wnd.parent.postMessage(msg, "*");
 	}-*/;
 
 	public static native void alert(String msg) /*-{

--- a/SurveyClient/src/main/java/uk/ac/ncl/openlab/intake24/client/survey/FlatFinalPage.java
+++ b/SurveyClient/src/main/java/uk/ac/ncl/openlab/intake24/client/survey/FlatFinalPage.java
@@ -41,6 +41,7 @@ import org.fusesource.restygwt.client.MethodCallback;
 import org.workcraft.gwt.shared.client.Callback1;
 import org.workcraft.gwt.shared.client.Callback2;
 import org.workcraft.gwt.shared.client.Option;
+import uk.ac.ncl.openlab.intake24.client.BrowserWindow;
 import uk.ac.ncl.openlab.intake24.client.EmbeddedData;
 import uk.ac.ncl.openlab.intake24.client.LoadingPanel;
 import uk.ac.ncl.openlab.intake24.client.api.auth.AuthCache;
@@ -101,6 +102,7 @@ public class FlatFinalPage implements SurveyStage<Survey> {
 
             @Override
             public void onSuccess(Method method, SurveySubmissionResponse response) {
+                BrowserWindow.postMessage("submitted");
                 contents.clear();
 
                 if (response.redirectToFeedback) {


### PR DESCRIPTION
Use case is when intake24 is being run embedded as part of another system or interface, postMessage allows the parent window to take action when submission is complete.